### PR TITLE
MPV2.5: refactor in order to remove the assumption of the single kin chain

### DIFF
--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -12,10 +12,19 @@
 #include <pfcGlobal.h>
 #include <creo2urdf/Utils.h>
 
-struct AxisInfo {
+enum class JointType {
+    Revolute,
+    Fixed,
+    Linear,
+    Spherical,
+    None
+};
+
+struct JointInfo {
     std::string name{""};
     std::string parent_link_name{""};
     std::string child_link_name{""};
+    JointType type {JointType::Revolute};
 };
 
 struct LinkInfo {
@@ -29,12 +38,12 @@ public:
     void OnCommand() override;
 
     bool exportModelToUrdf(iDynTree::Model mdl, iDynTree::ModelExporterOptions options);
-    void populateAxisInfoMap(pfcModel_ptr modelhdl);
+    void populateJointInfoMap(pfcModel_ptr modelhdl);
     bool addMeshAndExport(const std::string& link_child_name, const std::string& csys_name, pfcModel_ptr component_handle);
 
 private:
     iDynTree::Model idyn_model;
-    std::map<std::string, AxisInfo> axis_info_map;
+    std::map<std::string, JointInfo> joint_info_map;
     std::map<std::string, LinkInfo> link_info_map;
 };
 

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -12,16 +12,30 @@
 #include <pfcGlobal.h>
 #include <creo2urdf/Utils.h>
 
+struct AxisInfo {
+    std::string name{""};
+    std::string parent_link_name{""};
+    std::string child_link_name{""};
+};
+
+struct LinkInfo {
+    std::string name{""};
+    pfcModel_ptr modelhdl{ nullptr };
+    iDynTree::Transform root_H_link { iDynTree::Transform::Identity() };
+};
+
 class Creo2Urdf : public pfcUICommandActionListener {
 public:
     void OnCommand() override;
 
     bool exportModelToUrdf(iDynTree::Model mdl, iDynTree::ModelExporterOptions options);
-    bool addMeshAndExport(const std::string& link_child_name, const std::string& csys_name);
+    void populateAxisInfoMap(pfcModel_ptr modelhdl);
+    bool addMeshAndExport(const std::string& link_child_name, const std::string& csys_name, pfcModel_ptr component_handle);
 
 private:
-    pfcModel_ptr component_handle;
     iDynTree::Model idyn_model;
+    std::map<std::string, AxisInfo> axis_info_map;
+    std::map<std::string, LinkInfo> link_info_map;
 };
 
 class Creo2UrdfAccess : public pfcUICommandAccessListener {

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -31,6 +31,7 @@
 #include <iDynTree/ModelIO/ModelExporter.h>
 #include <iDynTree/ModelIO/ModelLoader.h>
 #include <iDynTree/Model/RevoluteJoint.h>
+#include <iDynTree/Model/FixedJoint.h>
 #include <iDynTree/KinDynComputations.h>
 #include <iDynTree/Model/Traversal.h>
 

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -60,6 +60,18 @@ static const std::map<c2uLogLevel, std::string> log_level_key = {
 
 
 static const std::map<std::string, std::string> link_csys_map = {
+    {"SIM_ECUB_ROOT_LINK","SCSYS_ROOT"},
+    {"SIM_ECUB_TORSO_1","SCSYS_TORSO_1"},
+    {"SIM_ECUB_TORSO_2","SCSYS_TORSO_2"},
+    {"SIM_ECUB_CHEST","SCSYS_CHEST"},
+    {"SIM_ECUB_L_SHOULDER_1","SCSYS_L_SHOULDER_1"},
+    {"SIM_ECUB_L_SHOULDER_2","SCSYS_L_SHOULDER_2"},
+    {"SIM_ECUB_L_SHOULDER_3","SCSYS_L_SHOULDER_3"},
+    {"SIM_ECUB_L_UPPERARM","SCSYS_L_UPPERARM"},
+    {"SIM_ECUB_R_SHOULDER_1","SCSYS_R_SHOULDER_1"},
+    {"SIM_ECUB_R_SHOULDER_2","SCSYS_R_SHOULDER_2"},
+    {"SIM_ECUB_R_SHOULDER_3","SCSYS_R_SHOULDER_3"},
+    {"SIM_ECUB_R_UPPERARM","SCSYS_R_UPPERARM"},
     {"SIM_ECUB_HEAD_NECK_1", "SCSYS_NECK_1"},
     {"SIM_ECUB_HEAD_NECK_2", "SCSYS_NECK_2"},
     {"SIM_ECUB_HEAD_NECK_3", "SCSYS_NECK_3"},

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -68,12 +68,6 @@ static const std::map<std::string, std::string> link_csys_map = {
 };
 
 
-static const std::map<std::string, std::string> child_axis_map = {
-    {"SIM_ECUB_HEAD_NECK_2", "NECK_PITCH_AXIS"},
-    {"SIM_ECUB_HEAD_NECK_3", "NECK_ROLL_AXIS"},
-    {"SIM_ECUB_HEAD", "NECK_YAW_AXIS"},
-    {"SIM_ECUB_REALSENSE", "REALSENSE_PITCH_AXIS"}
-};
 
 class iDynRedirectErrors {
 public:
@@ -127,7 +121,7 @@ std::pair<bool, iDynTree::Transform> getTransformFromRootToChild(pfcComponentPat
 
 std::pair<bool, iDynTree::Transform> getTransformFromPart(pfcModel_ptr modelhdl, const std::string& link_child_name);
 
-std::pair<bool, iDynTree::Direction> getRotationAxisFromPart(pfcModel_ptr modelhdl, const std::string& link_child_name, iDynTree::Transform H_child);
+std::pair<bool, iDynTree::Direction> getRotationAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_child_name, iDynTree::Transform H_child);
 
 bool addMeshAndExport(pfcModel_ptr modelhdl, const std::string& link_child_name, const std::string& csys_name, iDynTree::Model& idyn_model);
 

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -90,11 +90,17 @@ void Creo2Urdf::OnCommand() {
     for (auto axis_info : axis_info_map) {
         auto parent_link_name   = axis_info.second.parent_link_name;
         auto child_link_name    = axis_info.second.child_link_name;
+
+        // This handles the case of a "cut" assembly, where we have an axis but we miss the child link.
+        if (child_link_name.empty()) {
+            continue;
+        }
+
         auto joint_name         = parent_link_name + "--" + child_link_name;
         auto axis_name          = axis_info.second.name;
         auto root_H_parent_link = link_info_map.at(parent_link_name).root_H_link;
         auto root_H_child_link  = link_info_map.at(child_link_name).root_H_link;
-        auto child_model = link_info_map.at(child_link_name).modelhdl;
+        auto child_model        = link_info_map.at(child_link_name).modelhdl;
         
         printToMessageWindow("AXIS " + axis_info.second.name + " has parent link: " + parent_link_name + " has child link : " + child_link_name);
         printToMessageWindow("Parent link H " + root_H_parent_link.toString());
@@ -141,8 +147,8 @@ void Creo2Urdf::OnCommand() {
     idyn_model_out.close();
 
     iDynTree::ModelExporterOptions export_options;
-    export_options.robotExportedName = "ECUB_HEAD";
-    export_options.baseLink = "SIM_ECUB_HEAD_NECK_1";
+    export_options.robotExportedName = "ECUB_UPPERBODY";
+    export_options.baseLink = "SIM_ECUB_ROOT_LINK";
 
     exportModelToUrdf(idyn_model, export_options);
 

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -90,21 +90,20 @@ void Creo2Urdf::OnCommand() {
     for (auto axis_info : axis_info_map) {
         auto parent_link_name   = axis_info.second.parent_link_name;
         auto child_link_name    = axis_info.second.child_link_name;
-
+        auto axis_name = axis_info.second.name;
+        printToMessageWindow("AXIS " + axis_name + " has parent link: " + parent_link_name + " has child link : " + child_link_name);
         // This handles the case of a "cut" assembly, where we have an axis but we miss the child link.
         if (child_link_name.empty()) {
             continue;
         }
 
         auto joint_name         = parent_link_name + "--" + child_link_name;
-        auto axis_name          = axis_info.second.name;
         auto root_H_parent_link = link_info_map.at(parent_link_name).root_H_link;
         auto root_H_child_link  = link_info_map.at(child_link_name).root_H_link;
         auto child_model        = link_info_map.at(child_link_name).modelhdl;
         
-        printToMessageWindow("AXIS " + axis_info.second.name + " has parent link: " + parent_link_name + " has child link : " + child_link_name);
-        printToMessageWindow("Parent link H " + root_H_parent_link.toString());
-        printToMessageWindow("Child  link H " + root_H_child_link.toString());
+        //printToMessageWindow("Parent link H " + root_H_parent_link.toString());
+        //printToMessageWindow("Child  link H " + root_H_child_link.toString());
 
         iDynTree::Direction axis;
         std::tie(ret, axis) = getRotationAxisFromPart(child_model, axis_name, child_link_name, root_H_child_link);
@@ -138,7 +137,7 @@ void Creo2Urdf::OnCommand() {
 
             return;
         }
-        printToMessageWindow("Joint " + joint_name);
+        //printToMessageWindow("Joint " + joint_name);
     }
 
 

--- a/src/creo2urdf/src/Utils.cpp
+++ b/src/creo2urdf/src/Utils.cpp
@@ -174,7 +174,7 @@ std::pair<bool, iDynTree::Transform> getTransformFromPart(pfcModel_ptr modelhdl,
     return { false, H_child };
 }
 
-std::pair<bool, iDynTree::Direction> getRotationAxisFromPart(pfcModel_ptr modelhdl, const std::string& link_child_name, iDynTree::Transform H_child) {
+std::pair<bool, iDynTree::Direction> getRotationAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_child_name, iDynTree::Transform H_child) {
 
     iDynTree::Direction axis_unit_vector;
 
@@ -192,8 +192,7 @@ std::pair<bool, iDynTree::Direction> getRotationAxisFromPart(pfcModel_ptr modelh
     for (size_t i = 0; i < axes_list->getarraysize(); i++)
     {
         auto axis_elem = pfcAxis::cast(axes_list->get(xint(i)));
-
-        if (string(axis_elem->GetName()) == child_axis_map.at(string(link_child_name)))
+        if (string(axis_elem->GetName()) == axis_name)
         {
             axis = axis_elem;
             // printToMessageWindow("The axis is called " + string(axis_elem->GetName()));

--- a/src/creo2urdf/src/Utils.cpp
+++ b/src/creo2urdf/src/Utils.cpp
@@ -130,7 +130,6 @@ std::pair<bool, iDynTree::Transform> getTransformFromRootToChild(pfcComponentPat
 std::pair<bool, iDynTree::Transform> getTransformFromPart(pfcModel_ptr modelhdl, const std::string& link_child_name) {
 
     iDynTree::Transform H_child;
-
     auto csys_list = modelhdl->ListItems(pfcModelItemType::pfcITEM_COORD_SYS);
     if (csys_list->getarraysize() == 0) {
         printToMessageWindow("There are no CSYS in the part " + link_child_name, c2uLogLevel::WARN);


### PR DESCRIPTION
In this PR I refactored the code in order to remove the assumption of the single kin chain.

In particular, I populate the idyntree model in two separate steps.
First, the plugin iterates over all the parts, retrieves all the mass and kin properties of the links, and adds links to the idyntree model. 
For what concern the joints instead, at this step, I am assuming that the first part that owns a specific axis is the parent link, and the second one will be the child link.
This is an approximation due to the fact right now I couldn't ask for this information from Creo.
After this iteration over all parts, I start adding the joints using the informations retrieved the previous step and voila, for the case of 1 kin chain (MVP2) it works flawlessly:

![immagine](https://github.com/icub-tech-iit/creo2urdf/assets/19152494/7c64b39d-aae9-4c92-a96b-5b04922989fe)


cc @traversaro @pattacini @mfussi66 @fiorisi 
