### PR TITLE
Make that exportAllUseradded option exports the frames w/ the original names

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The parameter accepted by the plugin are documented in the following.
 | Attribute name   | Type   | Default Value | Description  |
 |:----------------:|:---------:|:------------:|:-------------:|
 | `linkFrames`       | Array | empty | Structure mapping the link names to the displayName of their desired frame. Unfortunatly in URDF the link frame origin placement is not free, but it is constrained to be placed on the parent joint axis, hence this option is for now reserved to the root link and to links connected to their parent by a fixed joint |
-| `exportAllUseradded` |  Boolean | False | If true, export all SimMechanics frame tagged with `USERADDED` in the output URDF as fake links i.e. fake link with zero mass connected to a link with a fixed joint..  |
+| `exportAllUseradded` |  Boolean | False | If true, export all frames starting w/ `SCSYS` in the output URDF as fake links i.e. fake link with zero mass connected to a link with a fixed joint.  |
 | `exportedFrames` | Array | empty | Array of `displayName` of UserAdded frames to export. This are exported as fixed URDF frames, i.e. fake link with zero mass connected to a link with a fixed joint. |
 
 ###### Link Frames Parameters  (keys of elements of `linkFrames`)

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -491,7 +491,7 @@ void Creo2Urdf::populateExportedFrameInfoMap(pfcModel_ptr modelhdl) {
             }
             ExportedFrameInfo ef_info;
             ef_info.frameReferenceLink = getRenameElementFromConfig(link_name);
-            ef_info.exportedFrameName = csys_name + "_USERADDED";
+            ef_info.exportedFrameName = csys_name;
             exported_frame_info_map.insert(std::make_pair(csys_name, ef_info));
         }
         


### PR DESCRIPTION
This has the effect of allowing the exportation of the urdf even if we forgot to put in the `exportedFrames` list a frame used by a sensor.

After several trials/draft, this seems the solution with less impact, if the user does not want to add all the exportedFrames he can set
```yaml
exportAllUseradded: Yes
```
And he will have a urdf with a lot of frames, but that works

cc @pillai-s

It fixes #60