### PR TITLE
 Account for root/link rotation when saving inertia matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ project(creo2urdf LANGUAGES C CXX
 include(GNUInstallDirs)
 include(FeatureSummary)
 
-# Needed for https://github.com/robotology/idyntree/issues/1065
 find_package(Eigen3 REQUIRED)
 find_package(iDynTree REQUIRED)
 find_package(yaml-cpp REQUIRED)

--- a/src/creo2urdf/CMakeLists.txt
+++ b/src/creo2urdf/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(creo2urdf PRIVATE iDynTree::idyntree-modelio
                                         iDynTree::idyntree-high-level
                                         yaml-cpp
                                         LibXml2::LibXml2
+                                        Eigen3::Eigen
                                         protk_dllmd_NU
                                         otk_cpp_md
                                         otk_no222_md

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -390,7 +390,21 @@ iDynTree::SpatialInertia Creo2Urdf::computeSpatialInertiafromCreo(pfcMassPropert
     }
 
     iDynTree::Position com_child({ com->get(0) * scale[0] , com->get(1) * scale[1], com->get(2) * scale[2] });
-    com_child = H.inverse() * com_child;  // TODO verify
+
+    // Account for root_H_link transformation
+    // See https://github.com/icub-tech-iit/ergocub-software/issues/224#issuecomment-1985692598 for full contents
+
+    // The COM returned by Creo's GetGravityCenter seems to be expressed in the root frame, so we need 
+    // to transform it back to the link frame before passing it to iDynTree's fromRotationalInertiaWrtCenterOfMass
+    com_child = H.inverse() * com_child;
+
+    // The inertia returned by Creo's GetCenterGravityInertiaTensor seems to be expressed with the COM as the
+    // point in which it is expressed, and with the orientation of the root link, so we rotate it back with
+    // the orientation of the link frame, unless an assignedInertia is used
+    if (!assigned_inertia_flag) {
+        iDynTree::toEigen() = 
+    }
+
     double mass{ 0.0 };
     if (config["assignedMasses"][link_name].IsDefined()) {
         mass = config["assignedMasses"][link_name].as<double>();


### PR DESCRIPTION
This is a completely blind attempt to solve https://github.com/icub-tech-iit/ergocub-software/issues/224 . I did not tested it and not even compile it as I do not have Creo at the moment on my PC, but I guess it was the most efficient way to suggest a fix.