### PR TITLE
Add the support for running the creo2urdf headless

### DIFF
--- a/scripts/run_creo2urdf.ps1
+++ b/scripts/run_creo2urdf.ps1
@@ -1,0 +1,63 @@
+<#
+.SYNOPSIS
+    Converter for Creo assembly to URDF format.
+.DESCRIPTION
+    This script converts  Creo assembly to URDF format using the creo2urdf plugin.
+.PARAMETER asmPath
+    The path of the .asm file to be converted.
+.PARAMETER yamlPath
+    The path of the YAML configuration file will be used.
+.PARAMETER csvPath
+    The path of the CSV configuration file will be used.
+.PARAMETER outputPath
+    The path where the final output will be saved.
+.EXAMPLE
+    .\run_creo2urdf.ps1 -asmPath "C:\path\to\asm_file.asm" -yamlPath "C:\path\to\yaml_file.yaml" -csvPath "C:\path\to\csv_file.csv" -outputPath "C:\output\path"
+    This command converts the Creo file to URDF format using the specified paths.
+#>
+
+param (
+    [string]$asmPath,
+    [string]$yamlPath,
+    [string]$csvPath,
+    [string]$outputPath
+)
+
+Write-Host "Using asm path: $asmPath"
+Write-Host "Using yaml path: $yamlPath"
+Write-Host "Using csv path: $csvPath"
+Write-Host "Using output path: $outputPath"
+
+
+if ([string]::IsNullOrEmpty($env:CREO9_INSTALL_PATH)) {
+    Write-Host "CREO9_INSTALL_PATH not set, exiting."
+    Exit
+}
+if ([string]::IsNullOrEmpty($asmPath)) {
+    Write-Host "asm path not specified, exiting."
+    Exit
+}
+if ([string]::IsNullOrEmpty($yamlPath)) {
+    Write-Host "yaml path not specified, exiting."
+    Exit
+}
+if ([string]::IsNullOrEmpty($csvPath)) {
+    Write-Host "csv path not specified, exiting."
+    Exit
+}
+if ([string]::IsNullOrEmpty($outputPath)) {
+    Write-Host "output path not specified, exiting."
+    Exit
+}
+
+$parametricExe = "$env:CREO9_INSTALL_PATH\..\Parametric\bin\parametric.exe"
+Start-Process -FilePath $parametricExe -ArgumentList "-g:no_graphics", "-batch_mode", "creo2urdf", "+$asmPath", "+$yamlPath", "+$csvPath", "+$outputPath" -Wait
+
+# Check if model.urdf exists in the output path
+$urdfPath = Join-Path -Path $outputPath -ChildPath "model.urdf"
+if (Test-Path -Path $urdfPath) {
+    Write-Host "Conversion completed successfully. The URDF file is located at: $urdfPath"
+}
+else {
+    Write-Host "Conversion failed. The URDF file was not generated."
+}

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -61,6 +61,13 @@ public:
      */
     void OnCommand() override;
 
+    Creo2Urdf() = default;
+    ~Creo2Urdf() = default;
+    Creo2Urdf(const std::string& yaml_path, const std::string& csv_path, const std::string& output_path, pfcModel_ptr asm_model_ptr) : m_yaml_path(yaml_path),
+                                                                                                                                       m_csv_path(csv_path),
+                                                                                                                                       m_output_path(output_path),
+                                                                                                                                       m_asm_model_ptr(asm_model_ptr) { }
+
 private:
     /**
      * @brief Export the iDynTree model to URDF format if it is valid.
@@ -137,7 +144,10 @@ private:
     std::array<double, 3> originXYZ {0.0, 0.0, 0.0}; /**< Offset of the root link in XYZ (meters) wrt the world frame. */
     std::array<double, 3> originRPY {0.0, 0.0, 0.0}; /**< Orientation of the root link in Roll-Pitch-Yaw wrt the world frame. */
     bool warningsAreFatal{ true }; /**< Flag indicating whether warnings are treated as fatal errors. */
+    std::string m_yaml_path{ "" }; /**< Path to the YAML configuration file. */
+    std::string m_csv_path{ "" }; /**< Path to the CSV file containing joint information. */
     std::string m_output_path{ "" }; /**< Output path for the exported URDF file. */
+    pfcModel_ptr m_asm_model_ptr{ nullptr }; /**< Handle to the Creo model. */
 };
 
 class Creo2UrdfAccess : public pfcUICommandAccessListener {

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -20,15 +20,15 @@ void Creo2Urdf::OnCommand() {
 
     pfcSession_ptr session_ptr = pfcGetProESession();
     if (!session_ptr) {
-		printToMessageWindow("Failed to get the session", c2uLogLevel::WARN);
-		return;
-	}
+        printToMessageWindow("Failed to get the session", c2uLogLevel::WARN);
+        return;
+    }
     if (!m_asm_model_ptr) {
         m_asm_model_ptr = session_ptr->GetCurrentModel();
         if (!m_asm_model_ptr) {
-			printToMessageWindow("Failed to get the current model", c2uLogLevel::WARN);
-			return;
-		}
+            printToMessageWindow("Failed to get the current model", c2uLogLevel::WARN);
+            return;
+        }
     }
 
 
@@ -43,8 +43,8 @@ void Creo2Urdf::OnCommand() {
 
     // YAML file path
     if (m_yaml_path.empty()) {
-		m_yaml_path = string(session_ptr->UIOpenFile(yaml_file_open_option));
-	}
+        m_yaml_path = string(session_ptr->UIOpenFile(yaml_file_open_option));
+    }
     if (!loadYamlConfig(m_yaml_path))
     {
         printToMessageWindow("Failed to run Creo2Urdf!", c2uLogLevel::WARN);
@@ -52,10 +52,10 @@ void Creo2Urdf::OnCommand() {
     }
     // CSV file path
     if (m_csv_path.empty()) {
-		auto csv_file_open_option = pfcFileOpenOptions::Create("*.csv");
-		csv_file_open_option->SetDialogLabel("Select the csv");
-		m_csv_path = string(session_ptr->UIOpenFile(csv_file_open_option));
-	}
+        auto csv_file_open_option = pfcFileOpenOptions::Create("*.csv");
+        csv_file_open_option->SetDialogLabel("Select the csv");
+        m_csv_path = string(session_ptr->UIOpenFile(csv_file_open_option));
+    }
     rapidcsv::Document joints_csv_table(m_csv_path, rapidcsv::LabelParams(0, 0));
     // Output folder path
     if (m_output_path.empty()) {
@@ -239,7 +239,7 @@ void Creo2Urdf::OnCommand() {
             if (joint_info.second.type == JointType::Revolute) {
                 joint_sh_ptr = std::make_shared<iDynTree::RevoluteJoint>();
                 dynamic_cast<iDynTree::RevoluteJoint*>(joint_sh_ptr.get())->setAxis(iDynTree::Axis(axis, parent_H_child.getPosition()));
-			}
+            }
             else if (joint_info.second.type == JointType::Linear) {
                 joint_sh_ptr = std::make_shared<iDynTree::PrismaticJoint>();
                 dynamic_cast<iDynTree::PrismaticJoint*>(joint_sh_ptr.get())->setAxis(iDynTree::Axis(axis, parent_H_child.getPosition()));

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -373,6 +373,12 @@ void Creo2Urdf::OnCommand() {
 
     exportModelToUrdf(idyn_model, export_options);
 
+    // Let's clear the map in case of multiple click TODO UNIFY
+    m_yaml_path.clear();
+    m_csv_path.clear();
+    m_output_path.clear();
+    m_asm_model_ptr = nullptr;
+
     return;
 }
 

--- a/src/creo2urdf/src/main.cpp
+++ b/src/creo2urdf/src/main.cpp
@@ -24,8 +24,8 @@ ProError evaluateBatchMode(const std::string& asm_path, const std::string& yaml_
     pfcBaseSession* session = pfcGetProESession();
     if (!session) {
         ProTKPrintf("Creo2Urdf: impossible to retrieve the session");
-		return PRO_TK_GENERAL_ERROR;
-	}
+        return PRO_TK_GENERAL_ERROR;
+    }
 
     pfcModel_ptr asm_model_ptr{ nullptr };
 


### PR DESCRIPTION
I still have to manage to correctly pass the arguments to the plugin, and run it from terminal, but this should be required changes to make it possible.

It fixes #53 

cc @pattacini 