### PR TITLE
Add recursion in the assembly navigation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(GNUInstallDirs)
 include(FeatureSummary)
 
 find_package(Eigen3 REQUIRED)
-find_package(iDynTree REQUIRED)
+find_package(iDynTree 12.3.1 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(LibXml2 REQUIRED)
 

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -150,7 +150,6 @@ private:
     std::string m_csv_path{ "" }; /**< Path to the CSV file containing joint information. */
     std::string m_output_path{ "" }; /**< Output path for the exported URDF file. */
     pfcModel_ptr m_root_asm_model_ptr{ nullptr }; /**< Handle to the Creo model. */
-    ElementTreeManager m_element_tree; /**< Manager for the element tree. */
     pfcSession_ptr m_session_ptr{ nullptr }; /**< Handle to the Creo session. */
 };
 

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -124,7 +124,7 @@ private:
      */
     bool loadYamlConfig(const std::string& filename);
 
-    bool processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr model_owner, iDynTree::Transform parent_H_csysItem = iDynTree::Transform::Identity());
+    bool processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr model_owner, iDynTree::Transform parentAsm_H_csysAsm = iDynTree::Transform::Identity());
 
     /**
      * @brief Get the renamed element from the configuration.

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -66,7 +66,7 @@ public:
     Creo2Urdf(const std::string& yaml_path, const std::string& csv_path, const std::string& output_path, pfcModel_ptr asm_model_ptr) : m_yaml_path(yaml_path),
                                                                                                                                        m_csv_path(csv_path),
                                                                                                                                        m_output_path(output_path),
-                                                                                                                                       m_asm_model_ptr(asm_model_ptr) { }
+                                                                                                                                       m_root_asm_model_ptr(asm_model_ptr) { }
 
 private:
     /**
@@ -124,6 +124,8 @@ private:
      */
     bool loadYamlConfig(const std::string& filename);
 
+    bool processAsmItems(pfcModelItems_ptr asmListItems);
+
     /**
      * @brief Get the renamed element from the configuration.
      * @param elem_name The original element name.
@@ -147,7 +149,9 @@ private:
     std::string m_yaml_path{ "" }; /**< Path to the YAML configuration file. */
     std::string m_csv_path{ "" }; /**< Path to the CSV file containing joint information. */
     std::string m_output_path{ "" }; /**< Output path for the exported URDF file. */
-    pfcModel_ptr m_asm_model_ptr{ nullptr }; /**< Handle to the Creo model. */
+    pfcModel_ptr m_root_asm_model_ptr{ nullptr }; /**< Handle to the Creo model. */
+    ElementTreeManager m_element_tree; /**< Manager for the element tree. */
+    pfcSession_ptr m_session_ptr{ nullptr }; /**< Handle to the Creo session. */
 };
 
 class Creo2UrdfAccess : public pfcUICommandAccessListener {

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -124,7 +124,7 @@ private:
      */
     bool loadYamlConfig(const std::string& filename);
 
-    bool processAsmItems(pfcModelItems_ptr asmListItems);
+    bool processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr model_owner);
 
     /**
      * @brief Get the renamed element from the configuration.

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -124,7 +124,7 @@ private:
      */
     bool loadYamlConfig(const std::string& filename);
 
-    bool processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr model_owner);
+    bool processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr model_owner, iDynTree::Transform parent_H_csysItem = iDynTree::Transform::Identity());
 
     /**
      * @brief Get the renamed element from the configuration.

--- a/src/creo2urdf/include/creo2urdf/ElementTreeManager.h
+++ b/src/creo2urdf/include/creo2urdf/ElementTreeManager.h
@@ -64,7 +64,7 @@ public:
      * @param[out] joint_info_map A map containing joint information.
      * @return True if successful, false otherwise.
      */
-    bool populateJointInfoFromElementTree(pfcFeature_ptr feat, std::map<std::string, JointInfo>& joint_info_map);
+    bool populateJointInfoFromElementTree(pfcFeature_ptr feat, std::map<std::string, JointInfo>& joint_info_map, bool is_asm=false);
 
     /**
      * @brief Gets the constraint type between two assembled parts.
@@ -85,10 +85,10 @@ public:
     std::string getChildName();
 
 private:
-    wfcElementTree_ptr tree = nullptr; ///< Pointer to the ElementTree of the part as feature.
-    wfcWFeature_ptr wfeat = nullptr;   ///< Pointer to the part as feature.
-    pfcSolid_ptr parent_solid;         ///< Pointer to the parent solid.
-    pfcSolid_ptr child_solid;          ///< Pointer to the child solid.
+    wfcElementTree_ptr tree{ nullptr }; ///< Pointer to the ElementTree of the part as feature.
+    wfcWFeature_ptr wfeat{ nullptr };   ///< Pointer to the part as feature.
+    pfcSolid_ptr parent_solid{ nullptr };         ///< Pointer to the parent solid.
+    pfcSolid_ptr child_solid{ nullptr };          ///< Pointer to the child solid.
 
     /*
      * @brief Retrieves the name of a common datum for the given model item type.

--- a/src/creo2urdf/include/creo2urdf/ElementTreeManager.h
+++ b/src/creo2urdf/include/creo2urdf/ElementTreeManager.h
@@ -64,7 +64,7 @@ public:
      * @param[out] joint_info_map A map containing joint information.
      * @return True if successful, false otherwise.
      */
-    bool populateJointInfoFromElementTree(pfcFeature_ptr feat, std::map<std::string, JointInfo>& joint_info_map, bool is_asm=false);
+    bool populateJointInfoFromElementTree(pfcFeature_ptr feat, std::map<std::string, JointInfo>& joint_info_map);
 
     /**
      * @brief Gets the constraint type between two assembled parts.
@@ -126,4 +126,8 @@ private:
      * @return A pair representing the limits (min, max).
      */
     std::pair<double, double> retrieveLimits(pfcFeature_ptr feat);
+
+    // SEEMS to work but we need to investigate further, using this may allow to refactor the code deeply
+
+    pfcTransform3D_ptr retrieveTransform(pfcFeature_ptr feat);
 };

--- a/src/creo2urdf/include/creo2urdf/Sensorizer.h
+++ b/src/creo2urdf/include/creo2urdf/Sensorizer.h
@@ -65,18 +65,18 @@ struct Sensorizer {
 
     /**
      * @brief Builds a vector of XML trees as strings for force/torque sensors, 
-	 * starting from the information retrieved in the YAML. The XML trees are returned in this
-	 * way so that they can be added as blobs using iDynTree.
-	 * 
+     * starting from the information retrieved in the YAML. The XML trees are returned in this
+     * way so that they can be added as blobs using iDynTree.
+     * 
      * @return A vector of strings representing the XML blobs.
      */
     std::vector<std::string> buildFTXMLBlobs();
 
     /**
      * @brief Builds a vector of XML trees as strings for general sensors, 
-	 * starting from the information retrieved in the YAML. The XML trees are returned in this
-	 * way so that they can be added as blobs using iDynTree.
-	 * 
+     * starting from the information retrieved in the YAML. The XML trees are returned in this
+     * way so that they can be added as blobs using iDynTree.
+     * 
      * @return A vector of strings representing the XML blobs.
      */
     std::vector<std::string> buildSensorsXMLBlobs();

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -258,7 +258,8 @@ struct JointInfo {
 struct LinkInfo {
     std::string name{""}; ///< Name of the link.
     pfcModel_ptr modelhdl{nullptr}; ///< Pointer to the Creo model associated with the link.
-    iDynTree::Transform root_H_link{iDynTree::Transform::Identity()}; ///< 3D Transform from the root to the link's reference frame.
+    iDynTree::Transform rootAsm_H_linkFrame{iDynTree::Transform::Identity()}; ///< 3D Transform from the root to the link's reference frame.
+    iDynTree::Transform csysAsm_H_linkFrame{iDynTree::Transform::Identity()}; ///< 3D Transform from the assembly to the link's reference frame.
     std::string link_frame_name{""}; ///< Name of the link frame.
 };
 
@@ -400,7 +401,7 @@ void printRotationMatrix(pfcMatrix3D_ptr m);
 void sanitizeSTL(std::string stl);
 
 /**
- * @brief Retrieves the transformation from the root to a specified link frame in the context of a component path.
+ * @brief Retrieves the transformation from the owner assembly to a specified link frame in the context of a component path.
  *
  * @param comp_path component path that represents the assembly hierarchy.
  * @param modelhdl The part model in which the link frame is defined.
@@ -412,7 +413,7 @@ void sanitizeSTL(std::string stl);
  *         - The second element is an iDynTree::Transform representing the transformation from the root to the specified link frame.
  *           If the operation fails, this transformation will be an identity transformation.
  */
-std::pair<bool, iDynTree::Transform> getTransformFromRootToChild(pfcComponentPath_ptr comp_path, pfcModel_ptr modelhdl, const std::string& link_frame_name, const array<double, 3>& scale);
+std::pair<bool, iDynTree::Transform> getTransformFromOwnerToLinkFrame(pfcComponentPath_ptr comp_path, pfcModel_ptr modelhdl, const std::string& link_frame_name, const array<double, 3>& scale);
 
 /**
  * @brief Retrieves the transformation matrix representing the coordinate system of a specified link frame in the given part.
@@ -438,7 +439,7 @@ std::pair<bool, iDynTree::Transform> getTransformFromPart(pfcModel_ptr modelhdl,
  * @param scale The scaling factor for the origin of the child frame
  * @return std::pair<bool, iDynTree::Direction>  Pair containing a success/failure flag, and the axis direction
  */
-std::pair<bool, iDynTree::Direction> getAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_frame_name, const array<double, 3>& scale);
+std::tuple<bool, iDynTree::Direction, iDynTree::Transform> getAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_frame_name, const array<double, 3>& scale);
 
 /**
  * @brief Extracts the folder path from a file path.

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -437,7 +437,7 @@ std::pair<bool, iDynTree::Transform> getTransformFromPart(pfcModel_ptr modelhdl,
  * @param axis_name The name of the desired axis of which to retrieve the direction
  * @param link_frame_name The name of the frame belonging to modelhdl
  * @param scale The scaling factor for the origin of the child frame
- * @return std::pair<bool, iDynTree::Direction>  Pair containing a success/failure flag, and the axis direction
+ * @return std::tuple<bool, iDynTree::Direction, iDynTree::Transform>>  Tuple containing a success/failure flag, the axis direction, and the transform oldLink_H_newLink in order that the frame lies on the axis.
  */
 std::tuple<bool, iDynTree::Direction, iDynTree::Transform> getAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_frame_name, const array<double, 3>& scale);
 

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -186,7 +186,7 @@ struct FTSensorInfo {
     std::string frame{"sensor"}; ///< Frame associated with the FT sensor.
     std::string sensorName{""}; ///< Name of the FT sensor.
     std::string frameName{""}; ///< Name of the frame.
-    std::string linkName{" "}; ///< Name of the associated link.
+    std::string linkName{""}; ///< Name of the associated link.
     std::string exportedFrameName{""}; ///< Name of the exported frame.
     iDynTree::Transform parent_link_H_sensor{iDynTree::Transform::Identity()}; ///< 3D transform from parent link to sensor.
     iDynTree::Transform child_link_H_sensor{iDynTree::Transform::Identity()}; ///< 3D transform from child link to sensor.

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -60,7 +60,7 @@ bool Creo2Urdf::processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr mod
             link_frame_name = "ASM_CSYS";
         }
         else {
-			link_frame_name = "CSYS";
+            link_frame_name = "CSYS";
             urdf_link_name = getRenameElementFromConfig(link_name);
             for (const auto& lf : config["linkFrames"]) {
                 if (lf["linkName"].Scalar() != urdf_link_name)
@@ -74,7 +74,7 @@ bool Creo2Urdf::processAsmItems(pfcModelItems_ptr asmListItems, pfcModel_ptr mod
                 printToMessageWindow(link_name + " misses the frame in the linkFrames section, CSYS will be used instead", c2uLogLevel::WARN);
                 link_frame_name = "CSYS";
             }
-		}
+        }
         std::tie(ret, csysAsm_H_linkFrame) = getTransformFromOwnerToLinkFrame(comp_path, component_handle, link_frame_name , scale);
 
         parentAsm_H_linkFrame = parentAsm_H_csysAsm * csysAsm_H_linkFrame;

--- a/src/creo2urdf/src/ElementTreeManager.cpp
+++ b/src/creo2urdf/src/ElementTreeManager.cpp
@@ -43,7 +43,6 @@ bool ElementTreeManager::populateJointInfoFromElementTree(pfcFeature_ptr feat, s
 
 
     if (!retrieveSolidReferences()) {
-        printToMessageWindow("Could not retrieve solid references!", c2uLogLevel::WARN);
         return false;
     }
     joint.child_link_name = getChildName();

--- a/src/creo2urdf/src/Sensorizer.cpp
+++ b/src/creo2urdf/src/Sensorizer.cpp
@@ -269,10 +269,10 @@ void Sensorizer::assignTransformToSensors(const std::map<std::string, ExportedFr
             }
 
             if (link_info_map.find(cad_link_name) == link_info_map.end())
-			{
-				printToMessageWindow("Sensorizer: link " + cad_link_name + " not found in the link info map, sensor "+ s.sensorName + " skipped.", c2uLogLevel::WARN);
-				continue;
-			}
+            {
+                printToMessageWindow("Sensorizer: link " + cad_link_name + " not found in the link info map, sensor "+ s.sensorName + " skipped.", c2uLogLevel::WARN);
+                continue;
+            }
 
             auto link_info = link_info_map.at(cad_link_name);
             std::tie(ret, csys_H_additionalFrame) = getTransformFromPart(link_info.modelhdl, s.frameName, scale);

--- a/src/creo2urdf/src/Sensorizer.cpp
+++ b/src/creo2urdf/src/Sensorizer.cpp
@@ -119,6 +119,11 @@ void Sensorizer::assignTransformToFTSensor(const std::map<std::string, ExportedF
             f.second.child_link_H_sensor = exported_frame_info_map.at(f.second.frameName).linkFrame_H_additionalFrame * exported_frame_info_map.at(f.second.frameName).additionalTransformation;
         }
         else {
+            if (joint_info_map.find(f.second.frameName) == joint_info_map.end())
+            {
+                continue;
+            }
+
             JointInfo j_info = joint_info_map.at(f.second.frameName);
 
             LinkInfo parent_l_info = link_info_map.at(j_info.parent_link_name);

--- a/src/creo2urdf/src/Sensorizer.cpp
+++ b/src/creo2urdf/src/Sensorizer.cpp
@@ -40,6 +40,11 @@ void Sensorizer::readSensorsFromConfig(const YAML::Node & config)
         if (s["exportedFrameName"].IsDefined()) {
             exported_frame_name = s["exportedFrameName"].Scalar();
         }
+        std::vector<string> sensor_blobs;
+        if (s["sensorBlobs"].IsDefined())
+        {
+            sensor_blobs = s["sensorBlobs"].as<std::vector<std::string>>();
+        }
 
         try
         {
@@ -51,7 +56,7 @@ void Sensorizer::readSensorsFromConfig(const YAML::Node & config)
                                 export_frame,
                                 stringToEnum<SensorType>(sensor_type_map, s["sensorType"].Scalar()),
                                 update_rate,
-                                s["sensorBlobs"].as<std::vector<std::string>>() });
+                                sensor_blobs });
         }
         catch (YAML::Exception& e)
         {

--- a/src/creo2urdf/src/Sensorizer.cpp
+++ b/src/creo2urdf/src/Sensorizer.cpp
@@ -119,12 +119,18 @@ void Sensorizer::assignTransformToFTSensor(const std::map<std::string, ExportedF
             f.second.child_link_H_sensor = exported_frame_info_map.at(f.second.frameName).linkFrame_H_additionalFrame * exported_frame_info_map.at(f.second.frameName).additionalTransformation;
         }
         else {
-            if (joint_info_map.find(f.second.frameName) == joint_info_map.end())
+
+            auto joint_it = std::find_if(joint_info_map.begin(), joint_info_map.end(),
+                [f](const std::pair<std::string, JointInfo>& pair) {
+                    return pair.second.datum_name == f.second.frameName;
+                });
+
+            if (joint_it == joint_info_map.end())
             {
                 continue;
             }
 
-            JointInfo j_info = joint_info_map.at(f.second.frameName);
+            JointInfo j_info = joint_it->second;
 
             LinkInfo parent_l_info = link_info_map.at(j_info.parent_link_name);
             LinkInfo child_l_info = link_info_map.at(j_info.child_link_name);
@@ -261,6 +267,13 @@ void Sensorizer::assignTransformToSensors(const std::map<std::string, ExportedFr
                     break;
                 }
             }
+
+            if (link_info_map.find(cad_link_name) == link_info_map.end())
+			{
+				printToMessageWindow("Sensorizer: link " + cad_link_name + " not found in the link info map, sensor "+ s.sensorName + " skipped.", c2uLogLevel::WARN);
+				continue;
+			}
+
             auto link_info = link_info_map.at(cad_link_name);
             std::tie(ret, csys_H_additionalFrame) = getTransformFromPart(link_info.modelhdl, s.frameName, scale);
             if (!ret)


### PR DESCRIPTION
This is a first "quick and dirty" draft for recursively traverse the model tree.

It fixes #97 

