### PR TITLE
Move the linkFrames in case of the axis of the joint does not pass through the csys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ include(GNUInstallDirs)
 include(FeatureSummary)
 
 find_package(Eigen3 REQUIRED)
-find_package(iDynTree 12.3.1 REQUIRED)
+find_package(iDynTree 12.4.0 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(LibXml2 REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Generate URDF model from CREO Parametric mechanisms.
 - Subassemblies are **NOT** yet supported.
 - The joints are in position 0.
 - Right now it can handle only **REVOLUTE**, **PRISMATIC** and **FIXED** joints.
-- In each joint, the frame of the child link must lie on the joint's axis (https://github.com/icub-tech-iit/creo2urdf/issues/99).
 
 ## Installation from binaries
 

--- a/src/creo2urdf/CMakeLists.txt
+++ b/src/creo2urdf/CMakeLists.txt
@@ -69,6 +69,7 @@ add_compile_definitions(creo2urdf PUBLIC PRO_MACHINE=36
 # Link dependencies
 target_link_libraries(creo2urdf PRIVATE iDynTree::idyntree-modelio
                                         iDynTree::idyntree-high-level
+                                        iDynTree::idyntree-model
                                         yaml-cpp::yaml-cpp
                                         LibXml2::LibXml2
                                         Eigen3::Eigen

--- a/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
+++ b/src/creo2urdf/include/creo2urdf/Creo2Urdf.h
@@ -151,6 +151,7 @@ private:
     std::string m_output_path{ "" }; /**< Output path for the exported URDF file. */
     pfcModel_ptr m_root_asm_model_ptr{ nullptr }; /**< Handle to the Creo model. */
     pfcSession_ptr m_session_ptr{ nullptr }; /**< Handle to the Creo session. */
+    bool m_need_to_move_link_frames_to_be_compatible_with_URDF{ false }; /**< Flag indicating whether to move link frames to be compatible with URDF. */
 };
 
 class Creo2UrdfAccess : public pfcUICommandAccessListener {

--- a/src/creo2urdf/include/creo2urdf/Utils.h
+++ b/src/creo2urdf/include/creo2urdf/Utils.h
@@ -437,9 +437,9 @@ std::pair<bool, iDynTree::Transform> getTransformFromPart(pfcModel_ptr modelhdl,
  * @param axis_name The name of the desired axis of which to retrieve the direction
  * @param link_frame_name The name of the frame belonging to modelhdl
  * @param scale The scaling factor for the origin of the child frame
- * @return std::tuple<bool, iDynTree::Direction, iDynTree::Transform>>  Tuple containing a success/failure flag, the axis direction, and the transform oldLink_H_newLink in order that the frame lies on the axis.
+ * @return std::tuple<bool, iDynTree::Direction, iDynTree::Position>>  Tuple containing a success/failure flag, the axis direction, and the position of the middle point of the axis in the link csys in order that the frame lies on the axis.
  */
-std::tuple<bool, iDynTree::Direction, iDynTree::Transform> getAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_frame_name, const array<double, 3>& scale);
+std::tuple<bool, iDynTree::Direction, iDynTree::Position> getAxisFromPart(pfcModel_ptr modelhdl, const std::string& axis_name, const std::string& link_frame_name, const array<double, 3>& scale);
 
 /**
  * @brief Extracts the folder path from a file path.

--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -13,6 +13,7 @@
 
 #include <iDynTree/PrismaticJoint.h>
 #include <iDynTree/EigenHelpers.h>
+#include <iDynTree/ModelTransformers.h>
 
 #include <Eigen/Core>
 
@@ -440,7 +441,12 @@ void Creo2Urdf::OnCommand() {
 bool Creo2Urdf::exportModelToUrdf(iDynTree::Model mdl, iDynTree::ModelExporterOptions options) {
     iDynTree::ModelExporter mdl_exporter;
 
-    mdl_exporter.init(mdl);
+    // Convert modelToExport in a URDF-compatible model (using the default base link)
+    iDynTree::Model modelToExportURDFCompatible;
+
+    bool ok = iDynTree::moveLinkFramesToBeCompatibleWithURDFWithGivenBaseLink(mdl, modelToExportURDFCompatible);
+
+    mdl_exporter.init(modelToExportURDFCompatible);
     mdl_exporter.setExportingOptions(options);
 
     if (!mdl_exporter.isValid())

--- a/src/creo2urdf/src/Utils.cpp
+++ b/src/creo2urdf/src/Utils.cpp
@@ -200,9 +200,9 @@ std::tuple<bool, iDynTree::Direction, iDynTree::Position> getAxisFromPart(pfcMod
     }
 
     if (!axis) {
-		printToMessageWindow("Unable to find the axis " + axis_name + " in " + string(modelhdl->GetFullName()), c2uLogLevel::WARN);
-		return { false, axis_unit_vector, axis_mid_point_pos };
-	}
+        printToMessageWindow("Unable to find the axis " + axis_name + " in " + string(modelhdl->GetFullName()), c2uLogLevel::WARN);
+        return { false, axis_unit_vector, axis_mid_point_pos };
+    }
 
     auto axis_data = wfcWAxis::cast(axis)->GetAxisData();
 
@@ -220,14 +220,12 @@ std::tuple<bool, iDynTree::Direction, iDynTree::Position> getAxisFromPart(pfcMod
 
     // There are just two points in the array
 
-    if (link_frame_name == "CSYS") {
-        // We use the medium point of the axis as offset
-        pfcPoint3D_ptr pstart = axis_line->GetEnd1();
-        pfcPoint3D_ptr pend = axis_line->GetEnd2();
-        axis_mid_point_pos[0] = ((pend->get(0) + pstart->get(0)) / 2.0) * scale[0];
-        axis_mid_point_pos[1] = ((pend->get(1) + pstart->get(1)) / 2.0) * scale[1];
-        axis_mid_point_pos[2] = ((pend->get(2) + pstart->get(2)) / 2.0) * scale[2];
-    }
+    // We use the medium point of the axis as offset
+    pfcPoint3D_ptr pstart = axis_line->GetEnd1();
+    pfcPoint3D_ptr pend = axis_line->GetEnd2();
+    axis_mid_point_pos[0] = ((pend->get(0) + pstart->get(0)) / 2.0) * scale[0];
+    axis_mid_point_pos[1] = ((pend->get(1) + pstart->get(1)) / 2.0) * scale[1];
+    axis_mid_point_pos[2] = ((pend->get(2) + pstart->get(2)) / 2.0) * scale[2];
 
     axis_unit_vector = csys_H_linkFrame.inverse() * axis_unit_vector;  // We might benefit from performing this operation directly in Creo
     axis_unit_vector.Normalize();


### PR DESCRIPTION
It fixes:
- #99 

Thanks heap to @traversaro who added the required feature to idyntree.

This version of `creo2urdf` is able to export the urdf from the mistreated icub 2.5 simulation model, see:
- https://github.com/icub-tech-iit/creo2urdf/issues/99#issuecomment-2243021476