### PR TITLE
Add vcpkg manifest mode configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,14 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Automatically check for installation of dependencies with vcpkg
-# When ON, vcpkg install is ran every time cmake is ran
+# Set manifest mode to use vcpkg.json to resolve dependencies
 option(VCPKG_MANIFEST_MODE ON)
+
+# When ON, vcpkg install is ran every time configure is ran
 option(VCPKG_MANIFEST_INSTALL ON)
+
+# Force use of following triplet since thats the only config supported by Creo
+set(VCPKG_TARGET_TRIPLET "x64-windows-static-md")
 
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.19)
   cmake_policy(SET CMP0111 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Automatically check for installation of dependencies with vcpkg
+# When ON, vcpkg install is ran every time cmake is ran
+option(VCPKG_MANIFEST_MODE ON)
+option(VCPKG_MANIFEST_INSTALL ON)
+
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.19)
   cmake_policy(SET CMP0111 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,10 @@ set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Set manifest mode to use vcpkg.json to resolve dependencies
-option(VCPKG_MANIFEST_MODE ON)
+option(VCPKG_MANIFEST_MODE "Enable manifest mode to use vcpkg.json" ON)
 
 # When ON, vcpkg install is ran every time configure is ran
-option(VCPKG_MANIFEST_INSTALL ON)
+option(VCPKG_MANIFEST_INSTALL "Install dependencies in manifest mode" ON)
 
 # Force use of following triplet since thats the only config supported by Creo
 set(VCPKG_TARGET_TRIPLET "x64-windows-static-md")

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ Generate URDF model from CREO Parametric mechanisms.
 **Since it is under development, we cannot guarantee that the user interface of `creo2urdf` will not implement breaking changes. Be aware of this if you start using the code contained in this repository**
 
 ## CREO Parametric versions supported and tested
-- `9.0.2`
+- `9.0.8.0`
 
 ## Assumptions & limitations
 
-- In order to export the urdf of the robot, the relative CREO mechanism has to conform to [these guidelines](https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF).
-- Subassemblies are **NOT** yet supported.
-- The joints are in position 0.
+- To export the urdf of the robot, the CREO mechanism has to follow [these guidelines](https://github.com/icub-tech-iit/cad-libraries/wiki/Prepare-PTC-Creo-Mechanism-for-URDF).
+- The joints are assumed to be in position 0.
 - Right now it can handle only **REVOLUTE**, **PRISMATIC** and **FIXED** joints.
 
 ## Installation from binaries
@@ -19,12 +18,12 @@ Generate URDF model from CREO Parametric mechanisms.
 > Users are encountering issues using the dll, see https://github.com/icub-tech-iit/creo2urdf/issues/84
 
 > [!NOTE]  
-> The dll provided has not been unlocked, this means that for using the Toolkit licence is required
+> The provided dll has not been unlocked, therefore the Toolkit licence is required for using it
 > 
 
 Download `creo2urdf.zip` from the assets of the [latest release](https://github.com/icub-tech-iit/creo2urdf/releases/latest), and extract it in the folder you like.<br>
-Follow the [`Usage`](https://github.com/icub-tech-iit/creo2urdf/tree/master#usage) section instructions for completing the installation. <br>
 This archive contains the dll of the plugin and the `text` folder for running it. <br>
+Follow the [`Usage`](https://github.com/icub-tech-iit/creo2urdf/tree/master#usage) section instructions for completing the installation. <br>
 
 ## Installation from sources
 
@@ -34,15 +33,15 @@ Right now the `creo2urdf` plugin needs its dependencies to be compiled and linke
 
 - Download [vcpkg](https://github.com/microsoft/vcpkg): `git clone https://github.com/microsoft/vcpkg`
 - Bootstrap vcpkg: `.\vcpkg\bootstrap-vcpkg.bat`
-- Run `[path to vcpkg]/vcpkg install --triplet x64-windows-static-md eigen3 yaml-cpp rapidcsv libxml2 assimp idyntree`
 
 ### Build `creo2urdf`
 
-- Export `CREO9_INSTALL_PATH` pointing to the Creo9 installation folder, e.g. `C:\Program Files\PTC\Creo 9.0.2.0\Common Files`
-- Pass `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md` to the creo2urdf compilation.
+- Export `CREO9_INSTALL_PATH` pointing to the Creo9 installation folder, e.g. `C:\Program Files\PTC\Creo 9.0.8.0\Common Files`
+- Pass `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake` to the creo2urdf compilation.
+- Run the CMake `configure` step, then build the project:
+    - Within Visual Studio, you can do: **Project > Configure creo2urdf**, then **Build > Build all** 
 
 For those who use the CMake integration in Visual Studio, the `-DCMAKE_TOOLCHAIN_FILE` option should not be passed to `CMake command arguments`. Instead, the `vcpkg.cmake` file path must be passed in `CMake toolchain file`.
-
 
 ## Usage
 
@@ -54,16 +53,16 @@ name creo2urdf
 Startup dll
 Allow_stop True
 Delay_start False
-exec_file /path/to/creo2urdf.dll
-text_dir /path/to/creo2urdf/src/creo2urdf/text
+exec_file \path\to\creo2urdf.dll
+text_dir \path\to\creo2urdf\src\creo2urdf\text
 END
 ```
-- Open CREO Parametric and the first time you will need to accecpt to register the plugin
-- Load the mechanism of which you want to export the urdf
+- Open CREO Parametric: on the first time, you will need to accept the plugin registration
+- Load the assembly mechanism of which you want to export the urdf
 - Press the button
  <img src="https://github.com/user-attachments/assets/d8ad3e71-baa4-40c4-9dbc-084962d425d3" width=800 align=center >
 
-- Select a yaml and csv configuration files with a format explained in the following sections, and the folder where the urdf and the meshes will be saved.
+- Select a yaml and csv configuration files with a format explained in the following sections, and the folder where both the urdf the meshes will be saved.
 
 
 ### Test your installation

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,10 +7,5 @@
     "yaml-cpp",
     "libxml2",
     "rapidcsv",
-    {
-      "name": "idyntree",
-      "version>=": "12.4.0"
-    }
-  ],
-  "builtin-baseline": "7a57b42f959ad138a5283477fe2e6c97a7cb852f"
+    "idyntree"]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "creo2urdf",
+  "homepage": "https://github.com/icub-tech-iit/creo2urdf",
+  "documentation": "https://icub-tech-iit.github.io/creo2urdf/doc/doxygen/doc/html/index.html",
+  "dependencies": [
+    "eigen3",
+    "yaml-cpp",
+    "libxml2",
+    "rapidcsv",
+    {
+      "name": "idyntree",
+      "version>=": "12.4.0"
+    }
+  ],
+  "builtin-baseline": "7a57b42f959ad138a5283477fe2e6c97a7cb852f"
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,5 +7,10 @@
     "yaml-cpp",
     "libxml2",
     "rapidcsv",
-    "idyntree"]
+    {
+      "name": "idyntree",
+      "version>=": "12.4.0"
+    }
+  ],
+  "builtin-baseline": "21bd538cbc3aa687d920d9399befb6c987c87942"
 }


### PR DESCRIPTION
This PR adds the vcpkg configuration in manifest mode, so that creo2urdf can have its dependencies installed separately from the system-wide vcpkg packages.
In this way, the user can just run `vcpkg install` in the top level directory and it will have the dependencies installed inside it. 

The command `vcpkg install` is ran every time the the CMake `configure` step is launched, and it will use the cached packages if they exist already.

Additionally, the triplet is set and not allowed as option since it's the only way to compile creo2urdf.