### PR TITLE
Deprecate CREO9_INSTALL_PATH in favour of CREO_INSTALL_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,13 +68,19 @@ endif()
 
 # FIXME add find_package CREO9
 
-if (NOT "$ENV{CREO9_INSTALL_PATH}" STREQUAL "")
-  set(CREO9_INSTALL_PATH "$ENV{CREO9_INSTALL_PATH}" CACHE INTERNAL "Copied from environment variable CREO9_INSTALL_PATH")
+if (NOT "$ENV{CREO_INSTALL_PATH}" STREQUAL "")
+  set(CREO_INSTALL_PATH "$ENV{CREO_INSTALL_PATH}" CACHE INTERNAL "Copied from environment variable CREO_INSTALL_PATH")
 else()
-  message( FATAL_ERROR "CREO9_INSTALL_PATH not set" )
+  if (NOT "$ENV{CREO9_INSTALL_PATH}" STREQUAL "")
+    message(WARNING "CREO9_INSTALL_PATH is deprecated. Please use CREO_INSTALL_PATH instead.")
+    set(CREO_INSTALL_PATH "$ENV{CREO9_INSTALL_PATH}" CACHE INTERNAL "Copied from deprecated environment variable CREO9_INSTALL_PATH")
+  else()
+    message(FATAL_ERROR "CREO_INSTALL_PATH not set")
+  endif()
 endif()
 
-message("CREO9_INSTALL_PATH = ${CREO9_INSTALL_PATH}")
+message("CREO_INSTALL_PATH = ${CREO_INSTALL_PATH}")
+
 
 #### Optional Dependencies
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Right now the `creo2urdf` plugin needs its dependencies to be compiled and linke
 
 ### Build `creo2urdf`
 
-- Export `CREO9_INSTALL_PATH` pointing to the Creo9 installation folder, e.g. `C:\Program Files\PTC\Creo 9.0.8.0\Common Files`
+- Export `CREO_INSTALL_PATH` pointing to the Creo9 installation folder, e.g. `C:\Program Files\PTC\Creo 9.0.8.0\Common Files`
 - Pass `-DCMAKE_TOOLCHAIN_FILE=[path to vcpkg]/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows-static-md` to the creo2urdf compilation.
 - Run the CMake `configure` step, then build the project:
     - Within Visual Studio, you can do: **Project > Configure creo2urdf**, then **Build > Build all** 

--- a/scripts/run_creo2urdf.ps1
+++ b/scripts/run_creo2urdf.ps1
@@ -29,8 +29,8 @@ Write-Host "Using csv path: $csvPath"
 Write-Host "Using output path: $outputPath"
 
 
-if ([string]::IsNullOrEmpty($env:CREO9_INSTALL_PATH)) {
-    Write-Host "CREO9_INSTALL_PATH not set, exiting."
+if ([string]::IsNullOrEmpty($env:CREO_INSTALL_PATH)) {
+    Write-Host "CREO_INSTALL_PATH not set, exiting."
     Exit 1
 }
 if ([string]::IsNullOrEmpty($asmPath)) {
@@ -50,7 +50,7 @@ if ([string]::IsNullOrEmpty($outputPath)) {
     Exit 1
 }
 
-$parametricExe = "$env:CREO9_INSTALL_PATH\..\Parametric\bin\parametric.exe"
+$parametricExe = "$env:CREO_INSTALL_PATH\..\Parametric\bin\parametric.exe"
 $process = Start-Process -FilePath $parametricExe -ArgumentList "-g:no_graphics", "-batch_mode", "creo2urdf", "+$asmPath", "+$yamlPath", "+$csvPath", "+$outputPath" -PassThru -NoNewWindow
 
 Start-Sleep -Seconds 30.0

--- a/src/creo2urdf/CMakeLists.txt
+++ b/src/creo2urdf/CMakeLists.txt
@@ -51,12 +51,12 @@ target_sources(creo2urdf
 target_include_directories(creo2urdf PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                                             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
                                             ${RAPIDCSV_INCLUDE_DIRS}
-                                            ${CREO9_INSTALL_PATH}/protoolkit/includes
-                                            ${CREO9_INSTALL_PATH}/otk/otk_cpp/include/
-                                            ${CREO9_INSTALL_PATH}/protoolkit/protk_appls/includes)
+                                            ${CREO_INSTALL_PATH}/protoolkit/includes
+                                            ${CREO_INSTALL_PATH}/otk/otk_cpp/include/
+                                            ${CREO_INSTALL_PATH}/protoolkit/protk_appls/includes)
 
-target_link_directories(creo2urdf PUBLIC    ${CREO9_INSTALL_PATH}/otk/otk_cpp/x86e_win64/obj/
-                                            ${CREO9_INSTALL_PATH}/protoolkit/x86e_win64/obj/)
+target_link_directories(creo2urdf PUBLIC    ${CREO_INSTALL_PATH}/otk/otk_cpp/x86e_win64/obj/
+                                            ${CREO_INSTALL_PATH}/protoolkit/x86e_win64/obj/)
 
 ## FIXME C++ 17 triggers "byte ambigous symbol" probably std::byte clashes with PTC defines
 target_compile_features(creo2urdf PUBLIC cxx_std_14)


### PR DESCRIPTION
It fixes #121