### PR TITLE
Fix move the linkFrames in case of the axis of the joint does not pass through the csys

### DIFF
--- a/src/creo2urdf/src/Creo2Urdf.cpp
+++ b/src/creo2urdf/src/Creo2Urdf.cpp
@@ -298,11 +298,11 @@ void Creo2Urdf::OnCommand() {
 
             auto urdf_parent_link_name = getRenameElementFromConfig(parent_link_name);
 
-            iDynTree::Axis idyn_axis{ direction, parentLink_H_childLink.getPosition() };
+            iDynTree::Axis idyn_axis{ direction, axis_mid_point_pos_in_parent };
 
             // Check if the axis is aligned with the link frame
-            if (parent_link_frame == "CSYS" && idyn_axis.getDistanceBetweenAxisAndPoint(axis_mid_point_pos_in_parent) > 1e-7 ) {
-                idyn_axis.setOrigin(axis_mid_point_pos_in_parent);
+            if (parent_link_frame == "CSYS" && idyn_axis.getDistanceBetweenAxisAndPoint(parentLink_H_childLink.getPosition()) > 1e-7 ) {
+                idyn_axis.setOrigin(parentLink_H_childLink.getPosition());
                 m_need_to_move_link_frames_to_be_compatible_with_URDF = true;
             }
 


### PR DESCRIPTION


This functionality was added in #106, but it was not coherent with the check made by idintree on the validity of the joint to be exported: https://github.com/robotology/idyntree/blob/9c2792790ca65ece633e8f8aed4d68716c65af09/src/model_io/codecs/src/URDFModelExport.cpp#L362-L371